### PR TITLE
netty-4-websockets: Fix upgrading connection in Firefox

### DIFF
--- a/netty-4-websockets/src/main/kotlin/org/httpobjects/websockets/HttpObjectsPlusWebsocketsHandler.kt
+++ b/netty-4-websockets/src/main/kotlin/org/httpobjects/websockets/HttpObjectsPlusWebsocketsHandler.kt
@@ -78,7 +78,7 @@ class HttpObjectsPlusWebsocketsHandler(
 
     private fun isWebsocketsUpgradeRequest(msg: HttpRequest):Boolean {
         val headers = msg.headers()
-        return ("Upgrade".equals(headers[HttpHeaderNames.CONNECTION], ignoreCase = true) &&
+        return ("Upgrade".contains(headers[HttpHeaderNames.CONNECTION], ignoreCase = true) &&
                 "WebSocket".equals(headers[HttpHeaderNames.UPGRADE], ignoreCase = true))
     }
 


### PR DESCRIPTION
Use `.contains` rather than `.equals`, as Firefox sets `Connection: keep-alive, Upgrade` rather than Chromium's `Connection: Upgrade`

See also: https://github.com/tjanczuk/iisnode/issues/497 and https://stackoverflow.com/questions/50192812/firefox-combining-connection-keep-alive-upgrade-conflicts-with-mobile-operat